### PR TITLE
Rename Angular2MeteorBase to AppComponent

### DIFF
--- a/client/app.component.ts
+++ b/client/app.component.ts
@@ -7,7 +7,7 @@ import { DemoComponent } from './imports/demo/demo.component';
   templateUrl: '/client/app.component.html',
   directives: [DemoComponent]
 })
-export class Angular2MeteorBase {
+export class AppComponent {
   constructor() {
 
   }

--- a/client/main.ts
+++ b/client/main.ts
@@ -1,5 +1,5 @@
 import { bootstrap } from 'angular2-meteor-auto-bootstrap';
 
-import { Angular2MeteorBase } from './app.component';
+import { AppComponent } from './app.component';
 
-bootstrap(Angular2MeteorBase);
+bootstrap(AppComponent);


### PR DESCRIPTION
To be more consistent with Angular2 Style Guide and more natural for people since file is called `app.component.ts`
