### PR TITLE
Fix(typings): @types/underscore & meteor-typings devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,12 +12,12 @@
   },
   "devDependencies": {
     "@types/chai": "3.4.34",
-    "@types/meteor": "^1.3.31",
     "@types/mocha": "2.2.34",
     "@types/underscore": "^1.7.36",
     "chai": "3.5.0",
     "chai-spies": "0.7.1",
-    "meteor-node-stubs": "0.2.4"
+    "meteor-node-stubs": "0.2.4",
+    "meteor-typings": "^1.3.1"
   },
   "dependencies": {
     "@angular/common": "2.4.1",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@types/chai": "3.4.34",
     "@types/meteor": "^1.3.31",
     "@types/mocha": "2.2.34",
+    "@types/underscore": "^1.7.36",
     "chai": "3.5.0",
     "chai-spies": "0.7.1",
     "meteor-node-stubs": "0.2.4"

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -33,7 +33,7 @@ declare module "meteor/hwillson:stub-collections" {
   import { Mongo } from "meteor/mongo";
 
   interface IStubCollections {
-    stub(collection: Mongo.Collection);
+    stub(collection: Mongo.Collection<any>);
     restore();
   }
 

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="zone.js" />
-/// <reference types="@types/meteor" />
+/// <reference types="meteor-typings" />
 /// <reference types="@types/underscore" />
 /// <reference types="@types/chai" />
 /// <reference types="@types/mocha" />


### PR DESCRIPTION
underscore typings definition is mentioned in `typings.d.ts`, but not included in `package.json`.
Therefore the definition file is actually missing (in case it is not already available globally I guess?).